### PR TITLE
16 use hydra for experiment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ cython_debug/
 #.idea/
 /data
 /models
+/outputs
 
 .ruff_cache/
 lightning_logs

--- a/conf/debug.yaml
+++ b/conf/debug.yaml
@@ -1,0 +1,20 @@
+data_config: {
+  total_ratio: 0.005,
+  validation_ratio: 0.1,
+  test_ratio: 0.05,
+  max_length_text: 1024,
+  max_length: 256,
+  data_loader_batch_size: 4
+}
+model_config: {
+  num_layers: 1,
+  intermediate_size: 512,
+  hidden_size: 512,
+  num_heads: 8,
+  max_position_embeddings: 512,
+}
+max_epochs: 1
+max_steps: 50
+val_check_interval: 5
+limit_val_batches: 10
+log_every_n_steps: 1

--- a/conf/process_data/debug.yaml
+++ b/conf/process_data/debug.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - process_data_config
+
+data_config: {
+  total_ratio: 0.005,
+  validation_ratio: 0.1,
+  test_ratio: 0.05,
+  max_length_text: 1024,
+  max_length: 256,
+  data_loader_batch_size: 4
+}

--- a/conf/train/debug.yaml
+++ b/conf/train/debug.yaml
@@ -1,0 +1,23 @@
+defaults:
+  - train_config
+
+data_config: {
+  total_ratio: 0.005,
+  validation_ratio: 0.1,
+  test_ratio: 0.05,
+  max_length_text: 1024,
+  max_length: 256,
+  data_loader_batch_size: 4
+}
+model_config: {
+  num_layers: 1,
+  intermediate_size: 512,
+  hidden_size: 512,
+  num_heads: 8,
+  max_position_embeddings: 256,
+}
+max_epochs: 1
+max_steps: 50
+val_check_interval: 5
+limit_val_batches: 10
+log_every_n_steps: 1

--- a/conf/train/quick.yaml
+++ b/conf/train/quick.yaml
@@ -1,3 +1,6 @@
+defaults:
+  - train_config
+
 data_config: {
   total_ratio: 0.005,
   validation_ratio: 0.1,
@@ -7,14 +10,14 @@ data_config: {
   data_loader_batch_size: 4
 }
 model_config: {
-  num_layers: 1,
-  intermediate_size: 512,
+  num_layers: 2,
+  intermediate_size: 1024,
   hidden_size: 512,
   num_heads: 8,
-  max_position_embeddings: 512,
+  max_position_embeddings: 256,
 }
 max_epochs: 1
-max_steps: 50
-val_check_interval: 5
-limit_val_batches: 10
-log_every_n_steps: 1
+max_steps: 2000
+val_check_interval: 200
+limit_val_batches: 50
+log_every_n_steps: 5

--- a/mlopstinystories/data/__init__.py
+++ b/mlopstinystories/data/__init__.py
@@ -1,3 +1,3 @@
-from .data_module import TinyStories
+from .data_module import TinyStories, TinyStoriesConfig
 
-__all__ = ["TinyStories"]
+__all__ = ["TinyStories", "TinyStoriesConfig"]

--- a/mlopstinystories/data/data_module.py
+++ b/mlopstinystories/data/data_module.py
@@ -1,5 +1,5 @@
-import json
 import os
+from dataclasses import dataclass
 from typing import List, Optional
 
 import datasets
@@ -11,16 +11,38 @@ from torch import Tensor
 from torch.utils.data import DataLoader, TensorDataset
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
-TOTAL_RATIO = 0.05
-VALIDATION_RATIO = 0.1
-TEST_RATIO = 0.05
-TOKENIZATION_BATCH_SIZE = 64
-MAX_LENGTH_TEXT = 1024
-MAX_LENGTH = 256
-DATA_LOADER_BATCH_SIZE = 4
+
+@dataclass
+class TinyStoriesConfig:
+    """
+    Configuration for the TinyStories dataset.
+
+    Attributes:
+        total_ratio (float): The ratio of the total dataset to use.
+        validation_ratio (float): The ratio of use data to use for validation.
+            The validation set will be `total_ratio * validation_ratio` of the total dataset.
+        test_ratio (float): The ratio of use data to use for testing.
+            The test set will be `total_ratio * test_ratio` of the total dataset.
+        max_length_text (int): The maximum length of the text in the dataset.
+            Texts longer than this will be discarded. If there are few than `total_ratio` texts shorter than this,
+            `total_ratio` will be ignored.
+        max_length (int): The maximum length of the tokenized text. Texts longer than this will be truncated.
+            It can therefore be a good idea to set this low enough that few texts shorter than `max_length_text`
+            have more tokens than `max_length`.
+        data_loader_batch_size (int): The batch size to use for the dataloaders.
+    """
+
+    total_ratio: float = 0.05
+    validation_ratio: float = 0.1
+    test_ratio: float = 0.05
+    max_length_text: int = 1024
+    max_length: int = 256
+    data_loader_batch_size: int = 4
 
 
 class TinyStories(LightningDataModule):
+    _config: TinyStoriesConfig
+
     _tokenizer: PreTrainedTokenizerFast
     _vocab_size: int
 
@@ -37,8 +59,10 @@ class TinyStories(LightningDataModule):
     _validation_tokens: Optional[Tensor]
     _test_tokens: Optional[Tensor]
 
-    def __init__(self, data_dir: str, device: torch.device) -> None:
+    def __init__(self, data_dir: str, device: torch.device, config: TinyStoriesConfig) -> None:
         super().__init__()
+
+        self._config = config
 
         self._tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neo-2.7B")  # type: ignore
         self._tokenizer.pad_token = self.tokenizer.eos_token
@@ -65,6 +89,10 @@ class TinyStories(LightningDataModule):
         self._test_tokens: Optional[Tensor] = None
 
     @property
+    def config(self) -> TinyStoriesConfig:
+        return self._config
+
+    @property
     def tokenizer(self) -> PreTrainedTokenizerFast:
         return self._tokenizer
 
@@ -86,9 +114,10 @@ class TinyStories(LightningDataModule):
         data = pd.concat([train_texts, validation_texts])
 
         # Shuffle the data and reset the index.
-        short = data[data["text"].apply(len) <= MAX_LENGTH_TEXT]
+        short = data[data["text"].apply(len) <= self.config.max_length_text]
         short_ratio = len(short) / len(data)
-        shuffled_data = short.sample(frac=TOTAL_RATIO / short_ratio, random_state=42).reset_index(drop=True)
+        sample_ratio = min(1, self.config.total_ratio / short_ratio)
+        shuffled_data = short.sample(frac=sample_ratio, random_state=42).reset_index(drop=True)
 
         strings = shuffled_data["text"].tolist()
 
@@ -96,15 +125,15 @@ class TinyStories(LightningDataModule):
             strings,
             add_special_tokens=True,
             padding="max_length",
-            max_length=MAX_LENGTH,
+            max_length=self.config.max_length,
             truncation=True,
             return_tensors="pt",
         )
         tokens: Tensor = tokenized_strings["input_ids"].to(torch.int32)  # type: ignore
 
         # Split the data into train, validation and test sets.
-        test_end_index = int(len(shuffled_data) * TEST_RATIO)
-        validation_end_index = int(len(shuffled_data) * (TEST_RATIO + VALIDATION_RATIO))
+        test_end_index = int(len(shuffled_data) * self.config.test_ratio)
+        validation_end_index = int(len(shuffled_data) * (self.config.test_ratio + self.config.validation_ratio))
 
         test_texts = shuffled_data[0:test_end_index]
         validation_texts = shuffled_data[test_end_index:validation_end_index]
@@ -124,15 +153,6 @@ class TinyStories(LightningDataModule):
         torch.save(validation_tokens.clone(), os.path.join(self._processed_dir, "validation_tokens.pt"))
         torch.save(test_tokens.clone(), os.path.join(self._processed_dir, "test_tokens.pt"))
 
-        info = {
-            "vocab_size": self.tokenizer.vocab_size,
-            "total_ratio": TOTAL_RATIO,
-            "validation_ratio": VALIDATION_RATIO,
-            "test_ratio": TEST_RATIO,
-            "max_length_text": MAX_LENGTH_TEXT,
-            "max_length": MAX_LENGTH,
-        }
-        json.dump(info, open(os.path.join(self._processed_dir, "info.json"), "w"))
         print("Data prepared.")
 
     def setup(self, stage: str) -> None:
@@ -161,7 +181,7 @@ class TinyStories(LightningDataModule):
         if pin_memory:
             train_loader: DataLoader[List[Tensor]] = DataLoader(  # type: ignore
                 self._train_set,
-                batch_size=DATA_LOADER_BATCH_SIZE,
+                batch_size=self.config.data_loader_batch_size,
                 shuffle=True,
                 num_workers=torch.get_num_threads(),
                 persistent_workers=True,
@@ -171,7 +191,7 @@ class TinyStories(LightningDataModule):
         else:
             train_loader = DataLoader(  # type: ignore
                 self._train_set,
-                batch_size=DATA_LOADER_BATCH_SIZE,
+                batch_size=self.config.data_loader_batch_size,
                 shuffle=True,
                 num_workers=torch.get_num_threads(),
                 persistent_workers=True,
@@ -186,7 +206,7 @@ class TinyStories(LightningDataModule):
         if pin_memory:
             validation_loader: DataLoader[List[Tensor]] = DataLoader(  # type: ignore
                 self._validation_set,
-                batch_size=DATA_LOADER_BATCH_SIZE,
+                batch_size=self.config.data_loader_batch_size,
                 num_workers=torch.get_num_threads(),
                 persistent_workers=True,
                 pin_memory=True,
@@ -195,7 +215,7 @@ class TinyStories(LightningDataModule):
         else:
             validation_loader = DataLoader(  # type: ignore
                 self._validation_set,
-                batch_size=DATA_LOADER_BATCH_SIZE,
+                batch_size=self.config.data_loader_batch_size,
                 num_workers=torch.get_num_threads(),
                 persistent_workers=True,
             )
@@ -208,7 +228,7 @@ class TinyStories(LightningDataModule):
         if pin_memory:
             test_loader: DataLoader[List[Tensor]] = DataLoader(  # type: ignore
                 self._test_set,
-                batch_size=DATA_LOADER_BATCH_SIZE,
+                batch_size=self.config.data_loader_batch_size,
                 num_workers=torch.get_num_threads(),
                 persistent_workers=True,
                 pin_memory=True,
@@ -217,7 +237,7 @@ class TinyStories(LightningDataModule):
         else:
             test_loader = DataLoader(  # type: ignore
                 self._test_set,
-                batch_size=DATA_LOADER_BATCH_SIZE,
+                batch_size=self.config.data_loader_batch_size,
                 num_workers=torch.get_num_threads(),
                 persistent_workers=True,
             )

--- a/mlopstinystories/data/data_module.py
+++ b/mlopstinystories/data/data_module.py
@@ -67,8 +67,6 @@ class TinyStories(LightningDataModule):
         self._config = config
 
         self._tokenizer = TinyStories.create_tokenizer()
-        self._tokenizer.pad_token = self.tokenizer.eos_token
-        self._tokenizer.pad_token = self.tokenizer.eos_token
         self._vocab_size = self.tokenizer.vocab_size
 
         self._data_dir = data_dir
@@ -93,7 +91,10 @@ class TinyStories(LightningDataModule):
 
     @staticmethod
     def create_tokenizer() -> PreTrainedTokenizerFast:
-        return AutoTokenizer.from_pretrained("EleutherAI/gpt-neo-2.7B")  # type: ignore
+        tokenizer: PreTrainedTokenizerFast = AutoTokenizer.from_pretrained("EleutherAI/gpt-neo-2.7B")  # type: ignore
+        tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+        return tokenizer
 
     @property
     def config(self) -> TinyStoriesConfig:

--- a/mlopstinystories/data/process_data.py
+++ b/mlopstinystories/data/process_data.py
@@ -1,13 +1,26 @@
+from dataclasses import dataclass
 from datetime import datetime
 
+import hydra
 import torch
 from data_module import TinyStories, TinyStoriesConfig
+from hydra.core.config_store import ConfigStore
 
 
-def main():
+@dataclass
+class ProcessDataConfig:
+    data_config: TinyStoriesConfig
+
+
+cs = ConfigStore.instance()
+
+cs.store(name="process_data_config", node=ProcessDataConfig)
+
+
+@hydra.main(config_path="../../conf/process_data", version_base="1.3")
+def main(config: ProcessDataConfig):
     start_time = datetime.now()
-    config = TinyStoriesConfig()
-    data = TinyStories("data", torch.device("cpu"), config)
+    data = TinyStories("data", torch.device("cpu"), config.data_config)
     data.prepare_data()
     end_time = datetime.now()
     print(f"Time to prepare data: {end_time - start_time}")

--- a/mlopstinystories/data/process_data.py
+++ b/mlopstinystories/data/process_data.py
@@ -2,13 +2,14 @@ import logging
 from datetime import datetime
 
 import torch
-from data_module import TinyStories
+from data_module import TinyStories, TinyStoriesConfig
 
 if __name__ == "__main__":
     log = logging.getLogger(__name__)
 
     start_time = datetime.now()
-    data = TinyStories("data", torch.device("cpu"))
+    config = TinyStoriesConfig()
+    data = TinyStories("data", torch.device("cpu"), config)
     data.prepare_data()
     end_time = datetime.now()
     print(f"Time to prepare data: {end_time - start_time}")

--- a/mlopstinystories/data/process_data.py
+++ b/mlopstinystories/data/process_data.py
@@ -1,15 +1,17 @@
-import logging
 from datetime import datetime
 
 import torch
 from data_module import TinyStories, TinyStoriesConfig
 
-if __name__ == "__main__":
-    log = logging.getLogger(__name__)
 
+def main():
     start_time = datetime.now()
     config = TinyStoriesConfig()
     data = TinyStories("data", torch.device("cpu"), config)
     data.prepare_data()
     end_time = datetime.now()
     print(f"Time to prepare data: {end_time - start_time}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlopstinystories/models/__init__.py
+++ b/mlopstinystories/models/__init__.py
@@ -1,3 +1,3 @@
-from .model import TinyStoriesConfig, TinyStoriesModel
+from .model import TinyStoriesModel, TinyStoriesModelConfig
 
-__all__ = ["TinyStoriesConfig", "TinyStoriesModel"]
+__all__ = ["TinyStoriesModelConfig", "TinyStoriesModel"]

--- a/mlopstinystories/models/model.py
+++ b/mlopstinystories/models/model.py
@@ -22,11 +22,12 @@ class TinyStoriesModelConfig:
 
     Args:
     ----
-        num_layers: Number of transformer layers.
-        intermediate_size: Size of the intermediate layer.
-        hidden_size: Size of the hidden layer.
-        num_heads: Number of attention heads.
-
+        num_layers (int): Number of transformer layers.
+        intermediate_size (int): Size of the intermediate layer.
+        hidden_size (int): Size of the hidden layer.
+        num_heads (int): Number of attention heads.
+        vocab_size (int): Size of vocabulary.
+        max_position_embeddings (int): The maximum sequence length that this model might ever be used with.
     """
 
     num_layers: int = 1

--- a/mlopstinystories/models/model.py
+++ b/mlopstinystories/models/model.py
@@ -17,7 +17,7 @@ MODELS_DIR = "models"
 
 
 @dataclass
-class TinyStoriesConfig:
+class TinyStoriesModelConfig:
     """TinyStories model configuration.
 
     Args:
@@ -52,7 +52,7 @@ class TinyStoriesModel(LightningModule):
         self._model = model
 
     @staticmethod
-    def initialize(config: TinyStoriesConfig, device: torch.device) -> "TinyStoriesModel":
+    def initialize(config: TinyStoriesModelConfig, device: torch.device) -> "TinyStoriesModel":
         """Initialize the model with the given configuration."""
         model_config = GPTNeoConfig(
             num_layers=config.num_layers,

--- a/mlopstinystories/predict_model.py
+++ b/mlopstinystories/predict_model.py
@@ -5,7 +5,8 @@ from data import TinyStories
 from device import get_device
 from models import TinyStoriesModel
 
-if __name__ == "__main__":
+
+def main():
     device = get_device()
 
     tokenizer = TinyStories.create_tokenizer()
@@ -28,8 +29,12 @@ if __name__ == "__main__":
     print([tokenizer.decode(token) for token in top_tokens])
 
     for _ in range(10):
-        generation_config = GenerationConfig(max_length=50, pad_token_id=50000, temperature=1.0, do_sample=True)
+        generation_config = GenerationConfig(max_length=50, pad_token_id=50000, temperature=0.5, do_sample=True)
         output_tokens = model.generate(input_tokens.to(device.torch()), generation_config)
         print("Output tokens: ", output_tokens)
         output_text = tokenizer.decode(output_tokens[0].to("cpu"))
         print("Output text: ", output_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlopstinystories/predict_model.py
+++ b/mlopstinystories/predict_model.py
@@ -1,17 +1,14 @@
 import torch
 from transformers.generation import GenerationConfig
 
-from data import TinyStories, TinyStoriesConfig
+from data import TinyStories
 from device import get_device
 from models import TinyStoriesModel
 
 if __name__ == "__main__":
     device = get_device()
 
-    config = TinyStoriesConfig()
-
-    data = TinyStories("data", device.torch(), config)
-    tokenizer = data.tokenizer
+    tokenizer = TinyStories.create_tokenizer()
 
     model = TinyStoriesModel.load("model1", device.torch())
 

--- a/mlopstinystories/predict_model.py
+++ b/mlopstinystories/predict_model.py
@@ -1,4 +1,8 @@
+from dataclasses import dataclass
+
+import hydra
 import torch
+from hydra.core.config_store import ConfigStore
 from transformers.generation import GenerationConfig
 
 from data import TinyStories
@@ -6,15 +10,29 @@ from device import get_device
 from models import TinyStoriesModel
 
 
-def main():
+@dataclass
+class PredictConfig:
+    model: str
+    input_text: str
+    temperature: float
+    num_samples: int
+    max_sample_length: int
+
+
+cs = ConfigStore.instance()
+
+cs.store(name="predict_config", node=PredictConfig)
+
+
+@hydra.main(config_path="../conf/predict", version_base="1.3")
+def main(config: PredictConfig):
     device = get_device()
 
     tokenizer = TinyStories.create_tokenizer()
 
-    model = TinyStoriesModel.load("model1", device.torch())
+    model = TinyStoriesModel.load(config.model, device.torch())
 
-    input_text = "Once upon a time, there was a girl named Alice. She was very silly and loved to"
-    input_tokens = tokenizer(input_text, return_tensors="pt").input_ids
+    input_tokens = tokenizer(config.input_text, return_tensors="pt").input_ids
     print("Input tokens: ", input_tokens)
 
     output = model(input_tokens.to(device.torch()))
@@ -28,10 +46,14 @@ def main():
     print("Top tokens: ", top_tokens.shape)
     print([tokenizer.decode(token) for token in top_tokens])
 
-    for _ in range(10):
-        generation_config = GenerationConfig(max_length=50, pad_token_id=50000, temperature=0.5, do_sample=True)
+    for _ in range(config.num_samples):
+        generation_config = GenerationConfig(
+            max_length=config.max_sample_length,
+            pad_token_id=tokenizer.pad_token_id,
+            temperature=config.temperature,
+            do_sample=True,
+        )
         output_tokens = model.generate(input_tokens.to(device.torch()), generation_config)
-        print("Output tokens: ", output_tokens)
         output_text = tokenizer.decode(output_tokens[0].to("cpu"))
         print("Output text: ", output_text)
 

--- a/mlopstinystories/predict_model.py
+++ b/mlopstinystories/predict_model.py
@@ -1,31 +1,16 @@
 import torch
 from transformers.generation import GenerationConfig
 
-from data import TinyStories
+from data import TinyStories, TinyStoriesConfig
 from device import get_device
 from models import TinyStoriesModel
-
-
-def predict(model: torch.nn.Module, dataloader: torch.utils.data.DataLoader) -> torch.Tensor:
-    """Run prediction for a given model and dataloader.
-
-    Args:
-    ----
-        model: model to use for prediction
-        dataloader: dataloader with batches
-
-    Returns:
-    -------
-        Tensor of shape [N, d] where N is the number of samples and d is the output dimension of the model
-
-    """
-    return torch.cat([model(batch) for batch in dataloader], 0)
-
 
 if __name__ == "__main__":
     device = get_device()
 
-    data = TinyStories("data", device.torch())
+    config = TinyStoriesConfig()
+
+    data = TinyStories("data", device.torch(), config)
     tokenizer = data.tokenizer
 
     model = TinyStoriesModel.load("model1", device.torch())

--- a/mlopstinystories/train_model.py
+++ b/mlopstinystories/train_model.py
@@ -25,14 +25,12 @@ class TrainModelConfig:
 
 cs = ConfigStore.instance()
 
-cs.store(name="config", node=TrainModelConfig)
+cs.store(name="train_config", node=TrainModelConfig)
 
 
-@hydra.main(config_path="../conf", config_name="config")
+@hydra.main(config_path="../conf/train", version_base="1.3")
 def main(config: TrainModelConfig) -> None:
     device = get_device()
-
-    print(config)
 
     repo_root = hydra.utils.get_original_cwd()
 

--- a/mlopstinystories/train_model.py
+++ b/mlopstinystories/train_model.py
@@ -6,7 +6,8 @@ from data import TinyStories, TinyStoriesConfig
 from device import get_device
 from models import TinyStoriesModel, TinyStoriesModelConfig
 
-if __name__ == "__main__":
+
+def main():
     device = get_device()
 
     data_config = TinyStoriesConfig()
@@ -48,3 +49,7 @@ if __name__ == "__main__":
     trainer.fit(model, datamodule=data)
 
     model.save("model1")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlopstinystories/train_model.py
+++ b/mlopstinystories/train_model.py
@@ -1,3 +1,8 @@
+import os
+from dataclasses import dataclass
+
+import hydra
+from hydra.core.config_store import ConfigStore
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import WandbLogger
@@ -7,22 +12,33 @@ from device import get_device
 from models import TinyStoriesModel, TinyStoriesModelConfig
 
 
-def main():
+@dataclass
+class TrainModelConfig:
+    data_config: TinyStoriesConfig
+    model_config: TinyStoriesModelConfig
+    max_epochs: int
+    max_steps: int
+    val_check_interval: int
+    limit_val_batches: int
+    log_every_n_steps: int
+
+
+cs = ConfigStore.instance()
+
+cs.store(name="config", node=TrainModelConfig)
+
+
+@hydra.main(config_path="../conf", config_name="config")
+def main(config: TrainModelConfig) -> None:
     device = get_device()
 
-    data_config = TinyStoriesConfig()
-    data = TinyStories("data", device.torch(), data_config)
+    print(config)
 
-    config = TinyStoriesModelConfig(
-        num_layers=2,
-        intermediate_size=512,
-        hidden_size=512,
-        num_heads=8,
-        vocab_size=data.vocab_size,
-        max_position_embeddings=512,
-    )
+    repo_root = hydra.utils.get_original_cwd()
 
-    model = TinyStoriesModel.initialize(config, device.torch())
+    data = TinyStories(os.path.join(repo_root, "data"), device.torch(), config.data_config)
+
+    model = TinyStoriesModel.initialize(config.model_config, device.torch())
     print("Device: ", model.device())
     print(f"Number of parameters: {model.num_params()}")
 
@@ -37,13 +53,13 @@ def main():
     trainer = Trainer(
         logger=WandbLogger(project="mlops-tinystories"),
         accelerator=device.lightning(),
-        max_epochs=1,
+        max_epochs=config.max_epochs,
         callbacks=[checkpoint_callback],
-        max_steps=50,
-        val_check_interval=5,
-        limit_val_batches=10,
-        log_every_n_steps=1,
-        num_sanity_val_steps=0,
+        max_steps=config.max_steps,
+        val_check_interval=config.val_check_interval,
+        limit_val_batches=config.limit_val_batches,
+        log_every_n_steps=config.log_every_n_steps,
+        num_sanity_val_steps=2,
     )
 
     trainer.fit(model, datamodule=data)

--- a/mlopstinystories/train_model.py
+++ b/mlopstinystories/train_model.py
@@ -2,16 +2,17 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import WandbLogger
 
-from data import TinyStories
+from data import TinyStories, TinyStoriesConfig
 from device import get_device
-from models import TinyStoriesConfig, TinyStoriesModel
+from models import TinyStoriesModel, TinyStoriesModelConfig
 
 if __name__ == "__main__":
     device = get_device()
 
-    data = TinyStories("data", device.torch())
+    data_config = TinyStoriesConfig()
+    data = TinyStories("data", device.torch(), data_config)
 
-    config = TinyStoriesConfig(
+    config = TinyStoriesModelConfig(
         num_layers=2,
         intermediate_size=512,
         hidden_size=512,


### PR DESCRIPTION
Example of usage:
To run `train_model.py` do `python mlopstinystories/train_model.py --config-name CONFIG_NAME` where `CONFIG_NAME` is replaced with the name of the config file in `conf/train/` (without `.yaml`) you would like to use. See https://hydra.cc/docs/advanced/override_grammar/basic/ for how to override specific settings. Hydra will create a new directory in `outputs/` for the run.