### PR TITLE
27 move data to gcp bucket instead of google drive

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,6 +1,8 @@
 [core]
-    remote = google_storage
+    remote = tiny_storage
 ['remote "storage"']
     url = gdrive://1Y4F7XwhrEUBiHIhg6EUzDgYvEtbVtgHV
 ['remote "google_storage"']
     url = gs://test_bucket_tiny/
+['remote "tiny_storage"']
+    url = gs://mlops-tiny-stories/

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,6 @@
 [core]
-    remote = storage
+    remote = google_storage
 ['remote "storage"']
     url = gdrive://1Y4F7XwhrEUBiHIhg6EUzDgYvEtbVtgHV
+['remote "google_storage"']
+    url = gs://test_bucket_tiny/

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,8 +1,4 @@
 [core]
-    remote = tiny_storage
-['remote "storage"']
-    url = gdrive://1Y4F7XwhrEUBiHIhg6EUzDgYvEtbVtgHV
+    remote = google_storage
 ['remote "google_storage"']
-    url = gs://test_bucket_tiny/
-['remote "tiny_storage"']
-    url = gs://mlops-tiny-stories/
+    url = gs://mlops_tiny/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,10 @@ torch ~= 2.1.0
 pytorch-lightning ~= 2.1.3
 pandas ~= 2.1.4
 huggingface-hub ~= 0.20.1
-dvs ~= 3.38.1
-dvc[gdrive]~=3.0.1
+dvc
+dvc[gs]
+dvc[gdrive]
+google-api-python-client
 # The next three I had to install manually to get `datasets` to work.
 multiprocess ~= 0.70.15
 xxhash ~= 3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ torch ~= 2.1.0
 pytorch-lightning ~= 2.1.3
 pandas ~= 2.1.4
 huggingface-hub ~= 0.20.1
-dvc
-dvc[gs]
+dvc ~= 3.39.0
+dvc[gs] 
 dvc[gdrive]
-google-api-python-client
+google-api-python-client ~= 2.113.0
 # The next three I had to install manually to get `datasets` to work.
 multiprocess ~= 0.70.15
 xxhash ~= 3.4.1


### PR DESCRIPTION
changed default dvc remote to point to our public dta bucket on google cloud storage. use dvc pull to get all data and models directories